### PR TITLE
Update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/juliangruber/reconnect-net",
   "main": "index.js",
   "dependencies": {
-    "reconnect-core": "~0.0.0"
+    "reconnect-core": "~1.1.0"
   },
   "keywords": [
     "reconnect",


### PR DESCRIPTION
Hi @juliangruber, looks like the reconnect-core dependency is still used in its 2013 version.